### PR TITLE
Update null_resource_count to trigger Terrateam

### DIFF
--- a/dev/main.tf
+++ b/dev/main.tf
@@ -2,5 +2,5 @@ module "dev" {
   source = "../modules"
 
   # Change 0 to 1 and open a pull request to trigger Terrateam
-  null_resource_count = 0
+  null_resource_count = 1
 }


### PR DESCRIPTION
This PR updates null_resource_count from 0 to 1 to trigger Terrateam as per the comment in the code.